### PR TITLE
Fix Git dependencies usage

### DIFF
--- a/lib/src/pubspec/dependency_builder_git.dart
+++ b/lib/src/pubspec/dependency_builder_git.dart
@@ -5,7 +5,7 @@ part of 'internal_parts.dart';
 class DependencyBuilderGit implements DependencyBuilder {
   DependencyBuilderGit({
     required this.name,
-    this.url,
+    required this.url,
     this.ref,
     this.path,
     List<String>? comments,
@@ -13,7 +13,7 @@ class DependencyBuilderGit implements DependencyBuilder {
 
   @override
   final String name;
-  final String? url;
+  final String url;
   final String? ref;
   final String? path;
   late final List<String> _comments;
@@ -21,6 +21,8 @@ class DependencyBuilderGit implements DependencyBuilder {
   /// List of comments to be prepended to the
   /// dependency.
   List<String> get comments => _comments;
+
+  bool get isSimple => ref == null && path == null;
 
   @override
   DependencyGit _attach(

--- a/lib/src/pubspec/dependency_git.dart
+++ b/lib/src/pubspec/dependency_git.dart
@@ -8,25 +8,31 @@ class DependencyGit with DependencyMixin implements Dependency {
       : _line = line,
         _section = SectionImpl.fromLine(line) {
     _name = _line.key;
-    final details = _GitDetails.fromLine(_line);
-
-    if (Strings.isNotBlank(_line.value) && details.refLine != null) {
-      throw PubSpecException(_line,
-          '''The git dependency for '$name has the url specified twice. ''');
-    }
+    _gitLine = _line.findRequiredKeyChild(keyName);
+    _details = _GitDetails.fromLine(_gitLine, _name);
   }
 
   /// Create a Git dependency and insert it into the document
   DependencyGit._insertAfter(
       PubSpec pubspec, Line lineBefore, DependencyBuilderGit dependency) {
     _name = dependency.name;
+    final url = dependency.url;
+    final isSimple = dependency.isSimple;
+    final directUrl = isSimple ? ' $url' : '';
+
     _line = LineImpl.forInsertion(pubspec.document, '  $_name:');
     pubspec.document.insertAfter(_line, lineBefore);
 
-    _details = _GitDetails(dependency);
-    _details._attach(_section, _line);
-
     _section = SectionImpl.fromLine(_line);
+    _details = _GitDetails(dependency);
+
+    _gitLine =
+        LineImpl.forInsertion(pubspec.document, '    $keyName:$directUrl');
+    pubspec.document.insertAfter(_gitLine, _line);
+
+    if (!isSimple) {
+      _details._attach(_section, _gitLine);
+    }
   }
 
   @override
@@ -40,6 +46,7 @@ class DependencyGit with DependencyMixin implements Dependency {
   late final _GitDetails _details;
 
   late final LineImpl _line;
+  late final LineImpl _gitLine;
 
   @override
   String get name => _name;
@@ -48,6 +55,13 @@ class DependencyGit with DependencyMixin implements Dependency {
     this.name = name;
     _line.key = name;
   }
+
+  @visibleForTesting
+  String get url => _details.url;
+  @visibleForTesting
+  String? get ref => _details.ref;
+  @visibleForTesting
+  String? get path => _details.path;
 
   @override
   Dependency add(DependencyBuilder dependency) {
@@ -68,16 +82,31 @@ class _GitDetails {
 
   /// Load the git details associated with the git dependency
   /// at [line]
-  _GitDetails.fromLine(LineImpl line)
+  _GitDetails.fromLine(LineImpl line, String name)
       : urlLine = line.findKeyChild('url'),
         refLine = line.findKeyChild('ref'),
         pathLine = line.findKeyChild('path') {
-    path = pathLine?.value;
-    ref = refLine?.value;
-    url = urlLine?.value;
+    String? url;
+    path = !pathLine!.missing ? pathLine!.value : null;
+    ref = !refLine!.missing ? refLine!.value : null;
+    url = !urlLine!.missing ? urlLine!.value : null;
+
+    if (Strings.isNotBlank(line.value) && Strings.isNotBlank(url)) {
+      throw PubSpecException(line,
+          '''The git dependency for '$name' has the url specified twice. ''');
+    }
+
+    url ??= line.value; // if the url is not a key then it may be the value.
+
+    if (Strings.isBlank(url)) {
+      throw PubSpecException(line,
+          '''The git dependency for '$name' requires a value or a 'url' key.''');
+    }
+
+    this.url = url;
   }
 
-  String? url;
+  late String url;
   String? ref;
   String? path;
 
@@ -112,7 +141,10 @@ class _GitDetails {
       required void Function(LineImpl) inserted}) {
     var attached = false;
     if (value != null) {
-      final _line = LineImpl.forInsertion(section.document, '    $key: $value');
+      final _line = LineImpl.forInsertion(
+        section.document,
+        '      $key: $value',
+      );
       section.document.insertAfter(_line, lineBefore);
       inserted(_line);
       attached = true;

--- a/test/src/pubspec/git_hosted_dependency_test.dart
+++ b/test/src/pubspec/git_hosted_dependency_test.dart
@@ -1,0 +1,192 @@
+import 'package:pubspec_manager/pubspec_manager.dart';
+import 'package:test/test.dart';
+
+import '../pubspec_test.dart';
+
+void main() {
+  group('git', () {
+    const gitDependency = 'kittens';
+    const gitUrl = 'https://github.com/munificent/kittens.git';
+    const gitRef = 'branch';
+    const gitPath = 'path/to/kittens';
+    test('Simple git dependency', () {
+      const content = '''
+name: pubspec3
+version: 0.0.1
+environment: 
+  sdk: '>=2.19.0 <3.0.0'
+dependencies: 
+  $gitDependency:
+    git: $gitUrl
+  flutter: 
+    sdk: flutter
+''';
+
+      final pubspec = PubSpec.loadFromString(content);
+      final dependency = pubspec.dependencies[gitDependency];
+
+      expect(dependency, isNotNull);
+      expect(
+          dependency,
+          isA<DependencyGit>()
+              .having((gitDep) => gitDep.url, 'url', equals(gitUrl)));
+    });
+    test('Composed git dependency', () {
+      const content = '''
+name: pubspec3
+version: 0.0.1
+environment: 
+  sdk: '>=2.19.0 <3.0.0'
+dependencies: 
+  $gitDependency:
+    git:
+      url: $gitUrl
+      ref: $gitRef
+      path: $gitPath
+  flutter: 
+    sdk: flutter
+''';
+
+      final pubspec = PubSpec.loadFromString(content);
+      final dependency = pubspec.dependencies[gitDependency];
+
+      expect(dependency, isNotNull);
+      expect(
+          dependency,
+          isA<DependencyGit>()
+              .having((gitDep) => gitDep.url, 'url', equals(gitUrl))
+              .having((gitDep) => gitDep.ref, 'ref', equals(gitRef))
+              .having((gitDep) => gitDep.path, 'path', equals(gitPath)));
+    });
+    test('Git dependency missing url', () {
+      const content = '''
+name: pubspec3
+version: 0.0.1
+environment: 
+  sdk: '>=2.19.0 <3.0.0'
+dependencies: 
+  $gitDependency:
+    git:
+      ref: $gitRef
+      path: $gitPath
+  flutter: 
+    sdk: flutter
+''';
+      expect(
+          () => PubSpec.loadFromString(content),
+          throwsA(isA<PubSpecException>().having(
+              (e) => e.message,
+              'Error message',
+              equals(
+                  '''The git dependency for '$gitDependency' requires a value or a 'url' key.'''))));
+    });
+    test('Git dependency url specified twice', () {
+      const content = '''
+name: pubspec3
+version: 0.0.1
+environment: 
+  sdk: '>=2.19.0 <3.0.0'
+dependencies: 
+  $gitDependency:
+    git: $gitUrl
+      url: $gitUrl
+      ref: $gitRef
+      path: $gitPath
+  flutter: 
+    sdk: flutter
+''';
+
+      expect(
+          () => PubSpec.loadFromString(content),
+          throwsA(isA<PubSpecException>().having(
+              (e) => e.message,
+              'Error message',
+              equals(
+                  '''The git dependency for '$gitDependency' has the url specified twice. '''))));
+    });
+
+    test('Add git dependency', () {
+      const testContent = '''
+name: pubspec3
+version: 0.0.1
+description: A simple command-line application created by dcli
+environment:
+  sdk: '>=2.19.0 <3.0.0' # an inline comment
+dependencies:
+  dcli: 2.3.0
+  dcli_core: 2.3.1
+  flutter:
+    sdk: flutter
+  $gitDependency:
+    git:
+      url: $gitUrl
+      ref: $gitRef
+      path: $gitPath
+  
+# only used during dev.
+dev_dependencies:
+  lint_hard: ^3.0.0
+  test: ^1.24.6
+
+topics:
+  - console
+  - terminal
+
+executables:
+  dcli:
+  dswitch: dswitcheroo
+''';
+      final pubspec = PubSpec.loadFromString(goodContent);
+
+      pubspec.dependencies.add(
+        DependencyBuilderGit(
+          name: gitDependency,
+          url: gitUrl,
+          path: gitPath,
+          ref: gitRef,
+        ),
+      );
+
+      expect(pubspec.toString(), equals(testContent));
+    });
+    test('Add simple git dependency', () {
+      const testContent = '''
+name: pubspec3
+version: 0.0.1
+description: A simple command-line application created by dcli
+environment:
+  sdk: '>=2.19.0 <3.0.0' # an inline comment
+dependencies:
+  dcli: 2.3.0
+  dcli_core: 2.3.1
+  flutter:
+    sdk: flutter
+  $gitDependency:
+    git: $gitUrl
+  
+# only used during dev.
+dev_dependencies:
+  lint_hard: ^3.0.0
+  test: ^1.24.6
+
+topics:
+  - console
+  - terminal
+
+executables:
+  dcli:
+  dswitch: dswitcheroo
+''';
+      final pubspec = PubSpec.loadFromString(goodContent);
+
+      pubspec.dependencies.add(
+        DependencyBuilderGit(
+          name: gitDependency,
+          url: gitUrl,
+        ),
+      );
+
+      expect(pubspec.toString(), equals(testContent));
+    });
+  });
+}


### PR DESCRIPTION
Hi,

As I build a CLI tool for my own, and I use Git dependencies in my pubspec.yaml, I get some issues.

My pubspec.yaml failed to be parsed due to this type of dependency, because the parser try to read `_GitDetails` directly below dependency name line; `git:` line was ignored.

Also, simple git dependency syntax was not supported (i.e `git: https://github.com/munificent/kittens.git`).

So here are some changes that I make to your code to make it works in my tool.

As I mainly target to fix issues I got, may I have missed some things to do. I provide some tests, but maybe they not follow your way to do it...
