### PR TITLE
Widen strings dependency range to include 4.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.3
+- Widen `strings` dependency range to include `4.0.0` release (no breaking changes).
+
 # 1.0.2
 - Fixed a parsing bug. If there was no version for the pubspec we would grab the version from the first dependency. We now only look for a version at the top level.
 - Fixed #17 - a comment line that appeared after the name of a depencency

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pubspec_manager
-version: 1.0.2
+version: 1.0.3
 description: Read, write and modify a pubspec.yaml with a type safe API including retention and modifications of comments and out of spec content.
 repository: https://github.com/onepub-dev/pubspec_manager
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   meta: ^1.9.1
   path: ^1.8.3
   pub_semver: ^2.1.4
-  strings: ^3.0.0
+  strings: '>=3.0.0 <5.0.0'
 dev_dependencies:
   lint_hard: ^4.0.0
   test: ^1.24.6


### PR DESCRIPTION
strings `4.0.0` was released on `Jun 3, 2025`, without breaking changes. https://pub.dev/packages/strings/changelog#400

Widening the range works without problems